### PR TITLE
Import clj-time periodic-seq function

### DIFF
--- a/src/cljs_time/periodic.cljs
+++ b/src/cljs_time/periodic.cljs
@@ -1,0 +1,13 @@
+(ns cljs-time.periodic
+  (:require [cljs-time.core :as time]))
+
+(defn periodic-seq
+  "Returns an infinite sequence of date-time values growing over specific period.
+  The 2 argument function takes as input the starting value and the growing value,
+  returning a lazy infinite sequence.
+  The 3 argument function takes as input the starting value, the upper bound value,
+  and the growing value, return a lazy sequence."
+  ([start period-like]
+   (iterate #(time/plus % period-like) start))
+  ([start end period-like]
+   (take-while #(time/before? % end) (periodic-seq start period-like))))

--- a/test/cljs_time/periodic_test.cljs
+++ b/test/cljs_time/periodic_test.cljs
@@ -1,0 +1,34 @@
+(ns cljs-time.periodic-test
+  (:refer-clojure :exclude [=])
+  (:require-macros
+    [cemerick.cljs.test :refer [is are deftest]])
+  (:require
+    [cemerick.cljs.test :as t]
+    [cljs-time.core :refer [= date-time hours months]]
+    [cljs-time.periodic :refer [periodic-seq]]))
+
+(deftest test-periodic-sequence
+  (let [d0  (date-time 2014 10 15 4 33)
+        d1  (date-time 2014 10 15 5 33)
+        d2  (date-time 2014 10 15 6 33)
+        d3  (date-time 2014 10 15 7 33)
+        d42 (date-time 2014 10 16 22 33)
+        s   (periodic-seq d0 (hours 1))]
+    (are [a b] (= a b)
+         d0  (first s)
+         d1  (second s)
+         d2  (nth s 2)
+         d3  (nth s 3)
+         d42 (nth s 42))))
+
+(deftest test-limited-periodic-sequence
+  (let [d0 (date-time 2014 11 25)
+        d1 (date-time 2014 12 25)
+        d2 (date-time 2015  1 25)
+        d3 (date-time 2015  2 25)
+        s  (periodic-seq d0 d3 (months 1))]
+    (are [a b] (= a b)
+         d0 (first s)
+         d1 (second s)
+         d2 (nth s 2))
+    (is (= 3 (count s)))))


### PR DESCRIPTION
I've imported a version of `periodic-seq` which works under `cljs-time`, following the structure and API from `clj-time`. I need to admit that the docs are the same from original version, because they are very good IMO and the behavior should be the same.

I'm also included a small set of tests to cover the new functionality.
