### PR TITLE
Catch ex-info thrown error

### DIFF
--- a/src/cljs_time/format.cljs
+++ b/src/cljs_time/format.cljs
@@ -406,7 +406,7 @@ time if supplied."}
   ([s]
      (first
       (for [f (vals formatters)
-            :let [d (try (parse f s) (catch js/Error _))]
+            :let [d (try (parse f s) (catch :default _))]
             :when d] d))))
 
 (defn parse-local


### PR DESCRIPTION
With the latest release of ClojureScript (3119), this is causing our builds to fail:

    Chrome 38.0.2125 (Linux) ERROR
      Uncaught #ExceptionInfo{:message "The parser could not match the input string.", :data {:type :parser-no-match}}
      at /home/ubuntu/frontend-private/resources/public/cljs/test/frontend-test.js:44127

Seems like catch isn't picking up ex-info errors as js/Error. This is a more general case that shouldn't cause any harm, while fixing our codebase + latest cljs.