### PR TITLE
Fix Google Closure goog.date link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the clj-time API can be replicated to make this library "good enough"
 for other projects.
 
 This library is currently leaning on the
-[Google Closure goog.date](http://docs.closure-library.googlecode.com/git/namespace_goog_date.html)
+[Google Closure goog.date](https://google.github.io/closure-library/api/namespace_goog_date.html)
 library for basic date/time functionality. **The date objects in this
 library are mutable**, however any operations that **alter** a date
 object return a copy, leaving the referenced date object alone. In the


### PR DESCRIPTION
The authoritative docs linked from https://developers.google.com/closure/library/ now point to the gh-pages site.