### PR TITLE
Support pr-str serialization/read-string deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ optionally you can require the `cljs-time.extend` namespace which will
 extend the goog.date.* datatypes, so that clojure.core/= works as
 expected.
 
+If you want your goog.date.* serializable with `pr-str`, require
+`cljs-time.instant` namespace.
+
 ### cljs-time.core
 
 The main namespace for date-time operations in the `cljs-time` library

--- a/src/cljs_time/instant.cljs
+++ b/src/cljs_time/instant.cljs
@@ -1,0 +1,20 @@
+(ns cljs-time.instant
+  (:require
+   [goog.date.DateTime]
+   [cljs-time.format :as fmt]))
+
+(extend-protocol IPrintWithWriter
+  goog.date.UtcDateTime
+  (-pr-writer [obj writer opts]
+    (-write writer "#inst ")
+    (pr-writer (tf/unparse (:date-time tf/formatters) obj) writer opts))
+
+  goog.date.DateTime
+  (-pr-writer [obj writer opts]
+    (-write writer "#inst ")
+    (pr-writer (tf/unparse (:date-time tf/formatters) obj) writer opts))
+
+  goog.date.Date
+  (-pr-writer [obj writer opts]
+    (-write writer "#inst ")
+    (pr-writer (tf/unparse (:date tf/formatters) obj) writer opts)))


### PR DESCRIPTION
So I'm thinking that would be nice to have, and I can implement it myself (I have it done for DateTime in my project already), but the question is - what's the best way to do it?

What I have right now is:

```
(extend-type goog.date.DateTime
  IPrintWithWriter
  (-pr-writer [o writer opts]
    (-write writer "#cljs-time/DateTime ")
    (pr-writer (tc/to-long o) writer opts)))

(cljs.reader/register-tag-parser! 'cljs-time/DateTime
  (fn [long]
    (tc/from-long long)))
```

I serialize it as long (I guess it should be faster), but it could be done as `#inst`, so that it will be interoperable with server-side Clojure?

Anyway, what's your thoughts?