### PR TITLE
Change timezone for builds to Australia to expose timezone bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - export TZ=Australia/Canberra
 language: clojure
 lein: lein2
 script: lein2 do clean, test-all


### PR DESCRIPTION
There is a bug in cljs-time which won't be exposed if you're running in UTC. This patch changes the timezone to expose the [bug](https://travis-ci.org/andrewmcveigh/cljs-time/jobs/111384776#L313), and it would probably be a good idea to keep it in this TZ to avoid future bugs slipping through.