### PR TITLE
Ensure to-epoch returns an integer

### DIFF
--- a/src/cljs_time/coerce.cljs
+++ b/src/cljs_time/coerce.cljs
@@ -50,7 +50,8 @@
 (defn to-epoch
   "Convert `obj` to Unix epoch."
   [obj]
-  (some-> obj to-long (/ 1000)))
+  (let [millis (to-long obj)]
+    (and millis (quot millis 1000))))
 
 (defn to-date
   "Convert `obj` to a JavaScript Date instance."

--- a/test/cljs_time/coerce_test.cljs
+++ b/test/cljs_time/coerce_test.cljs
@@ -1,6 +1,6 @@
 (ns cljs-time.coerce-test
   (:require
-   [cljs.test :refer-macros [deftest is]]
+   [cljs.test :refer-macros [deftest testing is]]
    [cljs-time.core
     :refer [date-time date-midnight from-utc-time-zone plus hours
             local-date local-date-time]]
@@ -81,7 +81,10 @@
   (is (= 893462400 (to-epoch (js/Date. 893462400000))))
   (is (= (long 0) (to-epoch 0)))
   (is (= 893462400 (to-epoch 893462400000)))
-  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.000Z"))))
+  (is (= 893462400 (to-epoch "1998-04-25T00:00:00.000Z")))
+  (testing "times with fractions of a second are rounded down"
+    (is (= 893462400 (to-epoch 893462400001)))
+    (is (= 893462400 (to-epoch 893462400999)))))
 
 (deftest test-to-string
   (is (nil? (to-string nil)))


### PR DESCRIPTION
The included test assertion is cribbed from [clj-time](https://github.com/clj-time/clj-time/blob/8713345e806cf581d0f890e94220e40b22a6b71f/test/clj_time/coerce_test.clj#L128).