### PR TITLE
Ensure to-local-date doesn't convert local-dates again

### DIFF
--- a/src/cljs_time/coerce.cljs
+++ b/src/cljs_time/coerce.cljs
@@ -70,8 +70,10 @@
   "Convert `obj` to a goog.date.Date instance"
   [obj]
   (when obj
-    (if-let [dt (to-date-time obj)]
-      (goog.date.Date. (.getYear dt) (.getMonth dt) (.getDate dt)))))
+    (if (= goog.date.Date (type obj))
+      obj
+      (if-let [dt (to-date-time obj)]
+        (goog.date.Date. (.getYear dt) (.getMonth dt) (.getDate dt))))))
 
 (defn to-local-date-time
   "Convert `obj` to a goog.date.DateTime instance"

--- a/test/cljs_time/coerce_test.cljs
+++ b/test/cljs_time/coerce_test.cljs
@@ -106,7 +106,8 @@
   (is (= (date/Date. 1998 3 25) (to-local-date (js/Date. 893462400000))))
   (is (= (date/Date. 1970 0 1) (to-local-date 0)))
   (is (= (date/Date. 1998 3 25) (to-local-date 893462400000)))
-  (is (= (date/Date. 1998 3 25) (to-local-date "1998-04-25T00:00:00.000Z"))))
+  (is (= (date/Date. 1998 3 25) (to-local-date "1998-04-25T00:00:00.000Z")))
+  (is (= (date/Date. 1998 3 25) (to-local-date (to-local-date "1998-04-25")))))
 
 (deftest test-to-local-date-time
   (is (nil? (to-local-date-time nil)))


### PR DESCRIPTION
Currently, to-local-date doesn't check if the parameter is already a local date. It always converts the parameter to UTC datetime at midnight (UTC). If the current time zone offset is positive, the result is on the previous day:
```
cljs.user=> (cljs-time.core/local-date 2016 12 13)
#object[Object 20161213]
cljs.user=> (cljs-time.coerce/to-local-date (cljs-time.core/local-date 2016 12 13))
#object[Object 20161212]
```
