### PR TITLE
don't construct ex-info if we don't need it

### DIFF
--- a/src/cljs_time/internal/parse.cljs
+++ b/src/cljs_time/internal/parse.cljs
@@ -137,8 +137,8 @@
   ([fmt]
    (fn [s]
      (let [[h & more] s
-           err (ex-info
-                (str "Invalid timezone format: " s) {:type :parse-error})
+           err #(ex-info
+                 (str "Invalid timezone format: " s) {:type :parse-error})
            dddd #(let [tz? (string/join (take 4 more))]
                    (when-let [[_ hh mm] (re-find #"^(\d{2})(\d{2})" tz?)]
                      [(timezone-adj % hh mm) (drop 4 more)]))
@@ -147,8 +147,8 @@
                      [(timezone-adj % hh mm) (drop 5 more)]))]
        (cond (#{\- \+} h)
              (case fmt
-               :dddd (or (dddd h) (long h) (throw err))
-               :long (or (dddd h) (long h) (throw err)))
+               :dddd (or (dddd h) (long h) (throw (err)))
+               :long (or (dddd h) (long h) (throw (err))))
              (= h \Z)
              [[:timezone (timezone-adj + "0" "0")]]
              :else
@@ -157,10 +157,10 @@
                            [tz _] (read-while #(re-find #"[A-Z]" %) tz?)]
                        (if (= (count tz) 3)
                          [[:timezone (string/join tz)] (drop 3 s)]
-                         (throw err)))
+                         (throw (err))))
                :full (throw (ex-info (str "Cannot parse long form timezone:" s)
                                      {:type :parse-error}))
-               (throw err)))))))
+               (throw (err))))))))
 
 (defn parse-meridiem
   ([]
@@ -267,16 +267,16 @@
   (loop [s value
          [parser & more] (map lookup (read-pattern pattern))
          out []]
-    (let [err (ex-info
-               (str "Invalid format: " value " is malformed at " (pr-str s))
-               {:type :parse-error :sub-type :invalid-format})]
+    (let [err #(ex-info
+                (str "Invalid format: " value " is malformed at " (pr-str s))
+                {:type :parse-error :sub-type :invalid-format})]
       (if (seq s)
         (if (nil? parser)
-          (throw err)
+          (throw (err))
           (let [[value s] (parser s)]
             (recur s more (conj out value))))
         (if parser
-          (throw err)
+          (throw (err))
           out)))))
 
 (defn compile [class {:keys [default-year] :as fmt} values]


### PR DESCRIPTION
Profiling an application that's parsing a thousand or so dates at a
time, I found that 75% of the time was spent constructing `ex-info`s
(specifically, it looks like getting the stack is a very expensive
operation).

![example](https://jds.objects-us-west-1.dream.io/screenshots/2017-02-26_15.26.54.png)

In most parsing cases, we probably won't actually be throwing any error,
so instead of wastefully constructing the `ex-info` every time, we can just
construct it when it's actually thrown.

I did this by just throwing the ex-info generation into a separate function, to avoid code repetition.