### PR TITLE
Swap build and test-all order in deploy task

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -112,4 +112,4 @@
   (comp (pom) (jar) (target)))
 
 (boot/deftask deploy []
-  (comp (test-all) (build) (install) (push)))
+  (comp (build) (test-all) (install) (push)))


### PR DESCRIPTION
Having `test-all` before `build` in the `deploy` task results in `boot-cljs-test` output artifacts ending up in the packaged jar. This is obviously not intended and also causes downstream problems.