### PR TITLE
Fix parse-quoted multi-char bug

### DIFF
--- a/src/cljs_time/internal/parse.cljs
+++ b/src/cljs_time/internal/parse.cljs
@@ -198,12 +198,13 @@
   (fn [s] (parse-period-name s :days i/days short?)))
 
 (defn parse-quoted [quoted]
-  (fn [s]
-    (let [s' (replace s (re-pattern (str \^ quoted)) "")]
-      (if (= s s')
-        (throw (ex-info "Quoted text not found"
-                        {:type :parse-error :where :parse-quoted}))
-        [[:quoted quoted] s']))))
+  (let [qpat (re-pattern (apply str \^ quoted))]
+    (fn [s]
+      (let [s' (replace s qpat "")]
+        (if (= s s')
+          (throw (ex-info "Quoted text not found"
+                          {:type :parse-error :where :parse-quoted}))
+          [[:quoted quoted] s'])))))
 
 (defn parse-ordinal-suffix []
   (fn [s]

--- a/test/cljs_time/format_test.cljs
+++ b/test/cljs_time/format_test.cljs
@@ -374,3 +374,8 @@
 (deftest parse-yy-test
   (is (= (date-time 2017 1 1)
          (format/parse (format/formatter "yy") "17"))))
+
+(deftest parse-quoted-test
+  (is (= (date-time 2017 7 1)
+         (format/parse (format/formatter "MMMM dd, YYYY 'at' H:mm a")
+                       "July 1, 2017 at 10:00 am"))))


### PR DESCRIPTION
Where quoted text was larger than one char, the regex we were building
to match quoted text was incorrect. We fix that and create the quoted
regex pattern in a closure, only constructing the pattern once per
parser.

Fixes: #103