### PR TITLE
Remove redundant form

### DIFF
--- a/src/cljs_time/core.cljs
+++ b/src/cljs_time/core.cljs
@@ -691,7 +691,6 @@ Specify the year, month, and day."
           (overlaps? start-a end-a start-b end-b)))
   ([start-a end-a start-b end-b]
      (or (and (before? start-b end-a) (after? end-b start-a))
-         (and (after? end-b start-a) (before? start-b end-a))
          (or (= start-a end-b) (= start-b end-a)))))
 
 (defn overlap


### PR DESCRIPTION
Very minor change removing redundant `and` form in `overlaps?` (noticed when comparing to `java-time` implementation).