### PR TITLE
Port cljs-time.core/min-date and cljs-time.core/max-date from the clj-time API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ out/
 clojurescript/
 doc/
 bin/
+.idea/

--- a/src/cljs_time/core.cljs
+++ b/src/cljs_time/core.cljs
@@ -312,6 +312,16 @@ expected."}
   []
   (doto (goog.date.UtcDateTime.) (.setTime 0)))
 
+(defn min-date
+  "Minimum of the provided DateTimes."
+  [dt & dts]
+  (reduce #(if (before? %1 %2) %1 %2) dt dts))
+
+(defn max-date
+  "Maximum of the provided DateTimes."
+  [dt & dts]
+  (reduce #(if (after? %1 %2) %1 %2) dt dts))
+
 (defn date-midnight
   "Constructs and returns a new DateTime at midnight in UTC.
 


### PR DESCRIPTION
I was looking for the [`min-date` & `max-date`](https://github.com/clj-time/clj-time/blob/3b828eb/src/clj_time/core.clj#L300-L308) functions, so I decided to add them in.  The implementation in clj-time isn't JVM-specific, so they're pretty easy to port over.